### PR TITLE
Use JS as modules for cleaner code

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,3 +1,5 @@
+import ApexCharts from 'apexcharts'
+
 const container = document.getElementById('container-graph')
 const form = document.getElementById('container-params')
 
@@ -86,3 +88,7 @@ function getData(endpoint) {
   const params = new URLSearchParams(getFormValues())
   fetch(`/data/${ endpoint }?${ params }`).then(r => r.ok ? r.json().then(handleApiData) : r.text().then(catchApiErrors))
 }
+
+// Inject the getData function into the window object so it can be called from the HTML
+// Because modules are isolated, we can't call functions from the HTML if not explicitly exported
+window.getData = getData

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -6,6 +6,14 @@
   <title>{% if title %}{{ title }} - {% endif %}Dendritic microcircuits</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 
+  <script type="importmap">
+    {
+      "imports": {
+        "apexcharts": "https://cdn.jsdelivr.net/npm/apexcharts@3.54.0/+esm"
+      }
+    }
+  </script>
+
   {% block head %}{% endblock %}
 </head>
 <body>

--- a/templates/base/experiment.html
+++ b/templates/base/experiment.html
@@ -1,9 +1,5 @@
 {% extends 'base/base.html' %}
 
-{% block head %}
-  <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
-{% endblock %}
-
 {% block container %}
   <div id="container-graph"></div>
   <form id="container-params">
@@ -23,5 +19,5 @@
 {% block postbody %}
   <script src="{{ url_for('static', filename='graph_types/column.js') }}"></script>
   <script src="{{ url_for('static', filename='graph_types/line.js') }}"></script>
-  <script src="{{ url_for('static', filename='script.js') }}"></script>
+  <script type="module" src="{{ url_for('static', filename='script.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
- Pin ApexCharts version to prevent unexpected updates
- Add importmap to specify apexcharts location
- Import JS script as module to use importmap
